### PR TITLE
don't close the stream

### DIFF
--- a/HttpMultipartParser/MultipartFormDataParser.cs
+++ b/HttpMultipartParser/MultipartFormDataParser.cs
@@ -239,31 +239,29 @@ namespace HttpMultipartParser
             this.BinaryBufferSize = binaryBufferSize;
             this.readEndBoundary = false;
 
-            using (var reader = new RebufferableBinaryReader(stream, this.Encoding, this.BinaryBufferSize))
+            var reader = new RebufferableBinaryReader(stream, this.Encoding, this.BinaryBufferSize);
+            // If we don't know the boundary now is the time to calculate it.
+            if (boundary == null)
             {
-                // If we don't know the boundary now is the time to calculate it.
-                if (boundary == null)
-                {
-                    boundary = DetectBoundary(reader);
-                }
-
-                // It's important to remember that the boundary given in the header has a -- appended to the start
-                // and the last one has a -- appended to the end
-                this.boundary = "--" + boundary;
-                this.endBoundary = this.boundary + "--";
-
-                // We add newline here because unlike reader.ReadLine() binary reading
-                // does not automatically consume the newline, we want to add it to our signature
-                // so we can automatically detect and consume newlines after the boundary
-                this.boundaryBinary = this.Encoding.GetBytes(this.boundary);
-                this.endBoundaryBinary = this.Encoding.GetBytes(this.endBoundary);
-
-                Debug.Assert(
-                    binaryBufferSize >= this.endBoundaryBinary.Length, 
-                    "binaryBufferSize must be bigger then the boundary");
-
-                this.Parse(reader);
+                boundary = DetectBoundary(reader);
             }
+
+            // It's important to remember that the boundary given in the header has a -- appended to the start
+            // and the last one has a -- appended to the end
+            this.boundary = "--" + boundary;
+            this.endBoundary = this.boundary + "--";
+
+            // We add newline here because unlike reader.ReadLine() binary reading
+            // does not automatically consume the newline, we want to add it to our signature
+            // so we can automatically detect and consume newlines after the boundary
+            this.boundaryBinary = this.Encoding.GetBytes(this.boundary);
+            this.endBoundaryBinary = this.Encoding.GetBytes(this.endBoundary);
+
+            Debug.Assert(
+                binaryBufferSize >= this.endBoundaryBinary.Length,
+                "binaryBufferSize must be bigger then the boundary");
+
+            this.Parse(reader);
         }
 
         #endregion

--- a/HttpMultipartParser/RebufferableBinaryReader.cs
+++ b/HttpMultipartParser/RebufferableBinaryReader.cs
@@ -35,7 +35,7 @@ namespace HttpMultipartParser
     ///     data similar to a <see cref="BinaryReader" /> and provides the ability to push
     ///     data onto the front of the stream.
     /// </summary>
-    internal class RebufferableBinaryReader : IDisposable
+    internal class RebufferableBinaryReader
     {
         #region Fields
 
@@ -135,14 +135,6 @@ namespace HttpMultipartParser
         public void Buffer(string data)
         {
             this.streamStack.Push(this.encoding.GetBytes(data));
-        }
-
-        /// <summary>
-        ///     Closes the stream.
-        /// </summary>
-        public void Dispose()
-        {
-            this.stream.Close();
         }
 
         /// <summary>

--- a/HttpMultipartParserUnitTest/HttpMultipartFormParserUnitTest.cs
+++ b/HttpMultipartParserUnitTest/HttpMultipartFormParserUnitTest.cs
@@ -456,6 +456,19 @@ namespace HttpMultipartParserUnitTest
             }
         }
 
+        [TestMethod]
+        public void DoesNotCloseTheStream()
+        {
+            using (Stream stream = TestUtil.StringToStream(TinyTestCase.Request, Encoding.UTF8))
+            {
+                var parser = new MultipartFormDataParser(stream, "boundry", Encoding.UTF8);
+                Assert.IsTrue(TinyTestCase.Validate(parser));
+
+                stream.Position = 0;
+                Assert.IsTrue(true, "if the stream was closed we'd get a ObjectDisposedException");
+            }
+        }
+
         #endregion
 
         /// <summary>


### PR DESCRIPTION
i have some code WCF code that uses the `MultipartFormDataParser` and after parsing i can't access  `ServiceSecurityContext` and some other informations anymore.
The problem is that `RebufferableBinaryReader` closes the stream.
