### PR TITLE
Fixed heavy CPU usage due to byte array allocation

### DIFF
--- a/HttpMultipartParser/StreamingMultipartFormDataParser.cs
+++ b/HttpMultipartParser/StreamingMultipartFormDataParser.cs
@@ -439,6 +439,7 @@ namespace HttpMultipartParser
             // file.
             var curBuffer = new byte[BinaryBufferSize];
             var prevBuffer = new byte[BinaryBufferSize];
+            var fullBuffer = new byte[BinaryBufferSize*2];
             int curLength = 0;
             int prevLength = 0;
 
@@ -449,7 +450,6 @@ namespace HttpMultipartParser
 
                 // Combine both buffers into the fullBuffer
                 // See: http://stackoverflow.com/questions/415291/best-way-to-combine-two-or-more-byte-arrays-in-c-sharp
-                var fullBuffer = new byte[BinaryBufferSize*2];
                 Buffer.BlockCopy(prevBuffer, 0, fullBuffer, 0, prevLength);
                 Buffer.BlockCopy(curBuffer, 0, fullBuffer, prevLength, curLength);
 


### PR DESCRIPTION
Moved fullBuffer byte array allocation to outside of the loop. If it's
in the loop, CLR Garbage Collector runs too frequently and causes high
CPU usage (even intermittent freezes). In my case, I was using
BinaryBufferSize of 81920 (80KB). With this fix, the new sequence finder
algorithm can work at full speed (12x-14x faster than old algorithm)