### PR TITLE
signal end of binary stream to subscribers

### DIFF
--- a/HttpMultipartParser/StreamingMultipartFormDataParser.cs
+++ b/HttpMultipartParser/StreamingMultipartFormDataParser.cs
@@ -521,6 +521,11 @@ namespace HttpMultipartParser
                     // and encoding
                     FileHandler(name, filename, contentType, contentDisposition, fullBuffer,
                                 endPos - bufferNewlineLength);
+                    if (endPos - bufferNewlineLength > 0)
+                    {
+                        // indicate end of stream to subscribers by passing zero for byte count, so they can close their stream
+                        FileHandler(name, filename, contentType, contentDisposition, new byte[0], 0);
+                    }
 
                     int writeBackOffset = endPos + endPosLength + boundaryNewlineOffset;
                     int writeBackAmount = (prevLength + curLength) - writeBackOffset;


### PR DESCRIPTION
There may of course be a less hackish way of handling this.

I personally make use of the change this way in my file handler:
```c#
streamHandler = (name, fileName, streamContentType, contentDisposition, buffer, bytes) =>
{
	if (bytes > 0)
	{
		fileStream.Write(buffer, 0, bytes);
	}
	else
	{
		// received EOS signal
		fileStream.Close();
		fileStream.Dispose();
		fileStream = null;
	}
};
```