### PR TITLE
Allow several values with same name

### DIFF
--- a/HttpMultipartParser/MultipartFormDataParser.cs
+++ b/HttpMultipartParser/MultipartFormDataParser.cs
@@ -203,7 +203,17 @@ namespace HttpMultipartParser
             Parameters = new Dictionary<string, ParameterPart>();
 
             var streamingParser = new StreamingMultipartFormDataParser(stream, boundary, encoding, binaryBufferSize);
-            streamingParser.ParameterHandler += parameterPart => Parameters.Add(parameterPart.Name, parameterPart);
+            streamingParser.ParameterHandler += parameterPart => {
+                if (Parameters.ContainsKey(parameterPart.Name))
+                {
+                    var oldValue = Parameters[parameterPart.Name].Data;
+                    Parameters[parameterPart.Name] = new ParameterPart(parameterPart.Name, oldValue + "," + parameterPart.Data);
+                }
+                else
+                {
+                    Parameters.Add(parameterPart.Name, parameterPart);
+                }
+            };
 
             streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes) =>
                 {

--- a/HttpMultipartParserUnitTest/HttpMultipartFormParserUnitTest.cs
+++ b/HttpMultipartParserUnitTest/HttpMultipartFormParserUnitTest.cs
@@ -312,6 +312,31 @@ namespace HttpMultipartParserUnitTest
                 }
             );
 
+        private static readonly string SeveralValuesWithSamePropertyTestData = TestUtil.TrimAllLines(
+            @"------B6u9lJxB4ByPiGPZ
+            Content-Disposition: form-data; name=""options""
+
+            value0
+            ------B6u9lJxB4ByPiGPZ
+            Content-Disposition: form-data; name=""options""
+
+            value1
+            ------B6u9lJxB4ByPiGPZ
+            Content-Disposition: form-data; name=""options""
+
+            value2
+            ------B6u9lJxB4ByPiGPZ--"
+            );
+
+        private static readonly TestData SeveralValuesWithSameProperty = new TestData(
+                SeveralValuesWithSamePropertyTestData,
+                new Dictionary<string, ParameterPart>
+                {
+                    {"options", new ParameterPart("options", "value0,value1,value2") }
+                },
+                new Dictionary<string, FilePart>()
+            );
+
         #endregion
 
         #region Public Methods and Operators
@@ -514,6 +539,16 @@ namespace HttpMultipartParserUnitTest
 
                 stream.Position = 0;
                 Assert.IsTrue(true, "A closed stream would throw ObjectDisposedException");
+            }
+        }
+
+        [TestMethod]
+        public void AcceptSeveralValuesWithSameProperty()
+        {
+            using (Stream stream = TestUtil.StringToStream(SeveralValuesWithSameProperty.Request, Encoding.UTF8))
+            {
+                var parser = new MultipartFormDataParser(stream, Encoding.UTF8);
+                Assert.IsTrue(SeveralValuesWithSameProperty.Validate(parser));
             }
         }
 


### PR DESCRIPTION
> Several checkboxes in a form may share the same control name. Thus, for example, checkboxes allow users to select several values for the same property.
>[source](http://www.w3.org/TR/REC-html40/interact/forms.html#checkbox)

currently a `ArgumentException` is thrown by the `Parameters` Dictionary

I have adapted the solution from `System.Web.HttpRequest.QueryString` which just joins the values with `,`
